### PR TITLE
Centralize the progress container

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,7 @@ export default function Index() {
         <div className="container">
           <h2 className="hero__title" title="Current decompilation progress">
             <Link to="/progress">
-            <span className="text-hilight">{progressText.data || "??.???%"}</span>
+            <span className="text-hilight">{progressText.data || "??.??%"}</span>
             </Link>
           </h2>
           <div className="row">

--- a/src/pages/progress.module.css
+++ b/src/pages/progress.module.css
@@ -5,7 +5,7 @@
 .container {
   flex: 0;
   align-self: center;
-  margin: 0 auto;
+  margin: 125px auto;
   max-width: 1000px;
   width: 100%;
 


### PR DESCRIPTION
The progress container on the website is shifted a bit far up. With this pr, the container gets pushed down more into the middle of the screen. Also removed one '?' symbol as the main page displays two digits after the comma for the progress instead of three.