### PR TITLE
format main.dol and rel inforows

### DIFF
--- a/src/pages/progress.tsx
+++ b/src/pages/progress.tsx
@@ -127,8 +127,8 @@ export default function Progress() {
       <div className={styles.container}>
         <h1>Decompilation Progress</h1>
         <InfoRow title="Total Code" value={totalCode} />
-        <InfoRow title="main.dol" value={dol} />
-        <InfoRow title="RELs" value={rels} />
+        <InfoRow title="main.dol" value={dol} secondLevel />
+        <InfoRow title="RELs" value={rels} secondLevel />
         <div className="chart-container" style={{ marginTop: 30, minHeight: 300 }}>
           {chartData && (
             <Chart


### PR DESCRIPTION
This small pr adds two "-" symbols right before the "main.dol" and "RELs" inforows in the progress page to signify that "main.dol" and "RELs" are subcategories of the "Total Code" inforow.